### PR TITLE
NativeAOT Target fixes for Android

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -90,9 +90,16 @@
   </Target>
 
   <Target Name="CopyNativeBinary" AfterTargets="Publish">
+    <PropertyGroup Condition="'$(IsAndroid)' == 'true'">
+      <NdkLibFolder Condition="'$(CrossCompileArch)' == 'arm'">$(CrossCompileArch)-linux-androideabi</NdkLibFolder>
+      <NdkLibFolder Condition="'$(CrossCompileArch)' == 'x86'">i686-linux-android</NdkLibFolder>
+      <NdkLibFolder Condition="'$(CrossCompileArch)' != 'arm' and '$(CrossCompileArch)' != 'x86'">$(CrossCompileArch)-linux-android</NdkLibFolder>
+    </PropertyGroup>
     <!-- override apphost with binary we generated during native compilation -->
     <Delete Files="$(PublishDir)\$(TargetName)$(NativeBinaryExt)" />
     <Copy SourceFiles="$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)" DestinationFolder="$(PublishDir)" />
+    <!--copy libc++_shared.so from NDK sysroot to publish directory-->
+    <Copy SourceFiles="$(SysRoot)/usr/lib/$(NdkLibFolder)/libc++_shared.so" DestinationFolder="$(PublishDir)" Condition="'$(IsAndroid)' == 'true'"/>
   </Target>
 
   <Target Name="CopyNativePdb" Condition="'$(DebugType)' != 'None' and '$(TargetOS)' == 'windows' and '$(NativeLib)' != 'Static'" AfterTargets="Publish">

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -18,6 +18,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <CppCompiler>$(CppCompilerAndLinker)</CppCompiler>
     <CppLinker>$(CppCompilerAndLinker)</CppLinker>
     <CppLibCreator>ar</CppLibCreator>
+    <IsAndroid>$(RuntimeIdentifier.StartsWith('android'))</IsAndroid>
   </PropertyGroup>
 
   <Target Name="SetupOSSpecificProps" DependsOnTargets="$(IlcDynamicBuildPropertyDependencies)">
@@ -27,15 +28,22 @@ The .NET Foundation licenses this file to you under the MIT license.
       <FullRuntimeName Condition="'$(ServerGarbageCollection)' == 'true'">libRuntime.ServerGC</FullRuntimeName>
 
       <CrossCompileRid />
-      <CrossCompileRid Condition="'$(TargetOS)' != 'OSX' and !$(RuntimeIdentifier.EndsWith('-$(OSHostArch)'))">$(RuntimeIdentifier)</CrossCompileRid>
+      <CrossCompileRid Condition="'$(TargetOS)' != 'OSX' and ('$(IsAndroid)' == 'true' or !$(RuntimeIdentifier.EndsWith('-$(OSHostArch)')))">$(RuntimeIdentifier)</CrossCompileRid>
 
       <CrossCompileArch />
       <CrossCompileArch Condition="$(CrossCompileRid.EndsWith('-x64'))">x86_64</CrossCompileArch>
+      <CrossCompileArch Condition="$(CrossCompileRid.EndsWith('-arm'))">arm</CrossCompileArch>
       <CrossCompileArch Condition="$(CrossCompileRid.EndsWith('-arm64'))">aarch64</CrossCompileArch>
-
+	  
       <TargetTriple />
-      <TargetTriple Condition="'$(CrossCompileArch)' != ''">$(CrossCompileArch)-linux-gnu</TargetTriple>
-      <TargetTriple Condition="'$(CrossCompileArch)' != '' and ($(CrossCompileRid.StartsWith('linux-musl')) or $(CrossCompileRid.StartsWith('alpine')))">$(CrossCompileArch)-alpine-linux-musl</TargetTriple>
+      <AndroidApiLevel Condition="'$(IsAndroid)' == 'true' and '$(AndroidApiLevel)' == ''">21</AndroidApiLevel>
+
+      <TargetTriple />      
+      <TargetTriple Condition="'$(IsAndroid)' == 'true' and '$(CrossCompileArch)' == 'arm'">arm-linux-androideabi$(AndroidApiLevel)</TargetTriple>
+      <TargetTriple Condition="'$(IsAndroid)' == 'true' and $(CrossCompileArch.StartsWith('x86'))">$(CrossCompileArch)-android$(AndroidApiLevel)</TargetTriple>
+      <TargetTriple Condition="'$(IsAndroid)' == 'true' and !$(CrossCompileArch.StartsWith('x86')) and '$(CrossCompileArch)' != 'arm'">$(CrossCompileArch)-linux-android$(AndroidApiLevel)</TargetTriple>
+      <TargetTriple Condition="'$(IsAndroid)' != 'true' and '$(CrossCompileArch)' != ''">$(CrossCompileArch)-linux-gnu</TargetTriple>
+      <TargetTriple Condition="'$(IsAndroid)' != 'true' and '$(CrossCompileArch)' != '' and ($(CrossCompileRid.StartsWith('linux-musl')) or $(CrossCompileRid.StartsWith('alpine')))">$(CrossCompileArch)-alpine-linux-musl</TargetTriple>
     </PropertyGroup>
 
     <ItemGroup>
@@ -47,11 +55,12 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup>
       <NetCoreAppNativeLibrary Include="System.Native" />
-      <NetCoreAppNativeLibrary Include="System.Globalization.Native" />
+      <NetCoreAppNativeLibrary Include="System.Globalization.Native"  Condition="'$(IsAndroid)' != 'true'" />
       <NetCoreAppNativeLibrary Include="System.IO.Compression.Native" />
-      <NetCoreAppNativeLibrary Include="System.Net.Security.Native" />
+      <NetCoreAppNativeLibrary Include="System.Net.Security.Native"  Condition="'$(IsAndroid)' != 'true'" />
       <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Apple" Condition="'$(TargetOS)' == 'OSX'" />
-      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.OpenSsl" Condition="'$(TargetOS)' != 'OSX'" />
+      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Android" Condition="'$(IsAndroid)' == 'true'" />
+      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.OpenSsl" Condition="'$(TargetOS)' != 'OSX'" Condition="'$(IsAndroid)' != 'true'" />
     </ItemGroup>
 
     <ItemGroup>
@@ -84,8 +93,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-lm" />
       <LinkerArg Include="-lz" />
       <LinkerArg Include="-static" Condition="'$(StaticallyLinked)' == 'true'" />
-      <LinkerArg Include="-lgssapi_krb5" Condition="'$(TargetOS)' != 'OSX' and '$(StaticallyLinked)' != 'true'" />
-      <LinkerArg Include="-lrt" Condition="'$(TargetOS)' != 'OSX'" />
+      <LinkerArg Include="-lgssapi_krb5" Condition="'$(TargetOS)' != 'OSX' and '$(StaticallyLinked)' != 'true' and '$(IsAndroid)' != 'true'" />
+      <LinkerArg Include="-lrt" Condition="'$(TargetOS)' != 'OSX' and '$(IsAndroid)' != 'true'" />
       <LinkerArg Include="-licucore" Condition="'$(TargetOS)' == 'OSX'" />
       <LinkerArg Include="-dynamiclib" Condition="'$(TargetOS)' == 'OSX' and '$(NativeLib)' == 'Shared'" />
       <LinkerArg Include="-shared" Condition="'$(TargetOS)' != 'OSX' and '$(NativeLib)' == 'Shared'" />


### PR DESCRIPTION
For a successfully compilation Android binaries we need to fix:
* Static libraries for NativeAOT Android.
* AndroidApiLevel parameter.
* TargetTriple argument.
* Include libc++_shared.so as part of published artifact.